### PR TITLE
Add (minimal) UI for subscriptions

### DIFF
--- a/code_comments/htdocs/code-comments.css
+++ b/code_comments/htdocs/code-comments.css
@@ -122,3 +122,11 @@ a.bubble span.ui-icon {
 	padding: 10px;
 	border-top: 1px solid #f5f5f5;
 }
+
+/* Subscriptions */
+
+button#subscribe {
+    display: block;
+    float: right;
+    margin: 5px 0 5px 5px;
+}

--- a/code_comments/htdocs/code-comments.css
+++ b/code_comments/htdocs/code-comments.css
@@ -126,7 +126,7 @@ a.bubble span.ui-icon {
 /* Subscriptions */
 
 button#subscribe {
-    display: block;
-    float: right;
-    margin: 5px 0 5px 5px;
+	display: block;
+	float: right;
+	margin: 5px 0 5px 5px;
 }

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -315,4 +315,53 @@ var underscore = _.noConflict();
 	AddCommentDialog.render();
 	LineCommentBubbles.render();
 	Rows.render();
+
+	window.Subscription = Backbone.Model.extend({
+		url: '/subscription' + location.pathname,
+	});
+
+	window.SubscriptionView = Backbone.View.extend({
+		el: $('button#subscribe'),
+
+		initialize: function(){
+			_.bindAll(this, "render");
+			this.model.listenTo(this.model, 'change', this.render);
+			this.render();
+		},
+
+		events: {
+			"click": "doToggle"
+		},
+
+		render: function(){
+			if (this.model.get('notify') == true) {
+				var options = {
+					disabled: false,
+					label: 'Unsubscribe',
+					icons: {primary: 'ui-icon-check'}
+				};
+			    var title = 'You receive notifications for comments';
+			} else {
+				var options = {
+					disabled: false,
+					label: 'Subscribe',
+					icons: {primary: 'ui-icon-closethick'}
+				};
+				var title = 'You do not receive notifications for comments';
+			}
+			var button = $(this.$el).button(options);
+			button.prop('title', title);
+		},
+
+		doToggle: function( event ){
+			this.model.save({'notify': !this.model.get('notify')}, {wait: true});
+			if (this.model.isNew()) {
+				this.model.fetch();
+			}
+		}
+	});
+
+	window.subscription = new Subscription();
+	window.subscriptionView = new SubscriptionView({model: subscription});
+	subscription.fetch();
 }); }( jQuery.noConflict( true ) ) );

--- a/code_comments/subscription.py
+++ b/code_comments/subscription.py
@@ -481,9 +481,7 @@ class SubscriptionModule(Component):
     def _do_GET(self, req):
         subscription = Subscription.for_request(self.env, req)
         if subscription is None:
-            raise HTTPNotFound('Subscription to /%s%s for %s not found',
-                               req.args.get('realm'), req.args.get('path'),
-                               req.authname)
+            req.send('', 'application/json', 204)
         req.send(json.dumps(subscription, cls=SubscriptionJSONEncoder),
                  'application/json')
 

--- a/code_comments/templates/code_comment_notify_email.txt
+++ b/code_comments/templates/code_comment_notify_email.txt
@@ -2,6 +2,8 @@ ${comment.text}
 
 View the comment: ${comment_url}
 
+To unsubscribe from future notifications, click the link above and use the "Unsubscribe" button.
+
 -- 
 ${project.name} <${project_url}>
 ${project.descr}


### PR DESCRIPTION
Added `SubscriptionModule` to handle subscriptions views:
- Inject a (disabled) button into `changeset`, `browser`, and
  `attachment` pages.
- Handle `GET`, `POST`, and `PUT` requests for subscriptions, accepting
  and returning only JSON content

Added `Subscription.for_request()` to get or create a subscription from
a request.

Added Backbone `Subscription` model and `SubscriptionView` view to
handle UI interaction.

Modified email template to let users know how to unsubscribe.
