### PR TITLE
Enable adding a comment to a git repository.

### DIFF
--- a/code_comments/comment.py
+++ b/code_comments/comment.py
@@ -96,7 +96,7 @@ class Comment:
 
     def changeset_link_text(self):
         if 0 != self.line:
-            return 'Changeset @%d#L%d (in %s)' % ( self.revision, self.line, self.path )
+            return 'Changeset @%s#L%d (in %s)' % ( self.revision, self.line, self.path )
         else:
             return 'Changeset @%s' % self.revision
 


### PR DESCRIPTION
This fixes the following error when adding a line comment to a changeset in a git repo:

```
2016-07-08 12:30:40,485 Trac[main] ERROR: Internal Server Error: <RequestWithSession "POST '/code-comments/comments'">, referrer '...'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/trac/web/main.py", line 562, in _dispatch_request
    dispatcher.dispatch(req)
  File "/usr/local/lib/python2.7/dist-packages/trac/web/main.py", line 249, in dispatch
    resp = chosen_handler.process_request(req)
  File "build/bdist.linux-x86_64/egg/code_comments/web.py", line 279, in process_request
    id = comments.create(json.loads(req.read()))
  File "build/bdist.linux-x86_64/egg/code_comments/comments.py", line 123, in create
    Comments(self.req, self.env).by_id(comment_id[0]))
  File "build/bdist.linux-x86_64/egg/code_comments/api.py", line 19, in comment_created
    listener.comment_created(comment)
  File "build/bdist.linux-x86_64/egg/code_comments/notification.py", line 20, in comment_created
    notifier.notify(comment)
  File "build/bdist.linux-x86_64/egg/code_comments/notification.py", line 105, in notify
    subject = "Re: [%s] %s" % (projname, comment.link_text())
  File "build/bdist.linux-x86_64/egg/code_comments/comment.py", line 84, in link_text
    return self.changeset_link_text()
  File "build/bdist.linux-x86_64/egg/code_comments/comment.py", line 99, in changeset_link_text
    return 'Changeset @%d#L%d (in %s)' % ( self.revision, self.line, self.path )
TypeError: %d format: a number is required, not unicode
```
