### PR TITLE
Allow alpha-numeric revision ids (e.g. git)

### DIFF
--- a/code_comments/comment.py
+++ b/code_comments/comment.py
@@ -96,7 +96,7 @@ class Comment:
 
     def changeset_link_text(self):
         if 0 != self.line:
-            return 'Changeset @%d#L%d (in %s)' % ( self.revision, self.line, self.path )
+            return 'Changeset @%s#L%d (in %s)' % ( self.revision, self.line, self.path )
         else:
             return 'Changeset @%s' % self.revision
 


### PR DESCRIPTION
When construction the URL for a link to a comment, the revision-ID was assumed to be numeric. This lead to errors when it in fact was not, e.g. when working with [git](https://git-scm.com).

Now the revision-ID is handled as a string.