### PR TITLE
Bugfix: Used wrong variable name.

### DIFF
--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -173,7 +173,7 @@ var underscore = _.noConflict();
 			// propoagating in order to avoid unexpected navigation while the
 			// user is typing their comment.
 			this.$el.keydown(function(e) {
-				event.stopPropagation();
+				e.stopPropagation();
 			});
 			this.$('button.add-comment').button();
 			return this;


### PR DESCRIPTION
A parameter was passed as ```e``` but addressed as ```event```, leading to error messages in the log.